### PR TITLE
Override React's loop factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,10 @@
     "autoload": {
         "psr-4": {
             "Amp\\ReactAdapter\\": "src"
-        }
+        },
+        "files": [
+            "etc/Factory.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/etc/Factory.php
+++ b/etc/Factory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace React\EventLoop;
+
+use Amp\ReactAdapter\ReactAdapter;
+
+/**
+ * Class used to overwrite React's loop factory with an implementation returning the adaptor.
+ *
+ * @noinspection PhpUndefinedClassInspection
+ */
+final class Factory
+{
+    public static function create(): LoopInterface
+    {
+        return ReactAdapter::get();
+    }
+}

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Amp\ReactAdapter\Test;
+
+use Amp\ReactAdapter\ReactAdapter;
+use PHPUnit\Framework\TestCase;
+use React\EventLoop\Factory;
+
+class FactoryTest extends TestCase
+{
+    public function testFactoryReturnsAdaptor()
+    {
+        $loop = Factory::create();
+        $this->assertInstanceOf(ReactAdapter::class, $loop);
+    }
+}


### PR DESCRIPTION
Since [React's loop factory](https://github.com/reactphp/event-loop/blob/85a0b7c0e35a47387a61d2ba8a772a7855b6af86/src/Factory.php) is a final class with no ability to add a user-defined implementation, this PR defines the same class and loads it before the autoloader has a chance to load the other version.